### PR TITLE
Changed node runtime version

### DIFF
--- a/terraform/jsonnet/lambda_functions.libsonnet
+++ b/terraform/jsonnet/lambda_functions.libsonnet
@@ -8,7 +8,7 @@
 				"role": "${aws_iam_role.lambda_proxy_api_handler.arn}",
 				"handler": "main.main",
 				"source_code_hash": "${data.archive_file.proxy_api_handler.output_base64sha256}",
-				"runtime": "nodejs8.10",
+				"runtime": "nodejs12.x",
 				"timeout": 60,
 
 				"dead_letter_config": {
@@ -22,7 +22,7 @@
 				"role": "${aws_iam_role.lambda_status_reporter.arn}",
 				"handler": "main.main",
 				"source_code_hash": "${data.archive_file.status_reporter.output_base64sha256}",
-				"runtime": "nodejs8.10",
+				"runtime": "nodejs12.x",
 				"timeout": 60,
 
 				"dead_letter_config": {
@@ -36,7 +36,7 @@
 				"role": "${aws_iam_role.lambda_spot_monitor.arn}",
 				"handler": "main.main",
 				"source_code_hash": "${data.archive_file.spot_monitor.output_base64sha256}",
-				"runtime": "nodejs8.10",
+				"runtime": "nodejs12.x",
 				"memory_size": 512,
 				"timeout": 10,
 


### PR DESCRIPTION
Nodejs8.10 runtime is now longer supported, changed to Nodejs12.x

Error when deploying:
Error creating Lambda function: InvalidParameterValueException: The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions.