### PR TITLE
fix json syntax error

### DIFF
--- a/terraform/npk-settings.json.sample
+++ b/terraform/npk-settings.json.sample
@@ -15,7 +15,7 @@
   "awsProfile": "npk",
   "criticalEventsSMS": "+13035551234",
   "adminEmail": "demo@npkproject.io",
-  "debug_lambda": false
+  "debug_lambda": false,
 
   "useSAML": false,
   "sAMLMetadataDocument": "/home/self/Documents/CorpSAMLMetadata.xml"


### PR DESCRIPTION
missing comma caused calls to jq in deploy.sh to fail with error like:
parse error: Expected separator between values at line 20, column 11