### PR TITLE
Add whitelist headers to avoid CORS errors.

### DIFF
--- a/terraform/jsonnet/cloudfront.libsonnet
+++ b/terraform/jsonnet/cloudfront.libsonnet
@@ -31,7 +31,7 @@
 					"target_origin_id": "static",
 					"forwarded_values": {
 						"query_string": false,
-
+						"headers": ["Origin","Access-Control-Allow-Origin","Access-Control-Request-Method","Access-Control-Request-Headers"],
 						"cookies": {
 							"forward": "none",
 						}


### PR DESCRIPTION
This will automatically add the whitelist headers in the Cloudfront distribution n deployment. I was facing multiple issues with CORS errors.