### PR TITLE
Fixed stopping a campaign after it has started running

### DIFF
--- a/terraform/lambda_functions/proxy_api_handler/main.js
+++ b/terraform/lambda_functions/proxy_api_handler/main.js
@@ -808,69 +808,71 @@ function executeCampaign(entity, campaignId) {
 
 function stopCampaign(entity, campaignId) {
 
-	return getCampaign(entity, campaignId).then(function(data) {
+	return getCampaign(entity, campaignId).then(function (data) {
 		if (data.Items.length < 1) {
 			return respond(404, "Campaign " + campaignId + " not found", false);
 		}
 
 		var campaign = ddbTypes.unwrap(data.Items[0]);
-		var ec2 = new aws.EC2({region: campaign.region});
+		var ec2 = new aws.EC2({
+			region: campaign.region
+		});
 
 		// Can be simplified by calling .promise() on the AwsRequest objects
 		return new Promise((success, failure) => {
-		ec2.describeSpotFleetRequests({
-			SpotFleetRequestIds: [campaign.spotFleetRequestId]
-		}, function(err, fleet) {
-			if (err) {
+			ec2.describeSpotFleetRequests({
+				SpotFleetRequestIds: [campaign.spotFleetRequestId]
+			}, function (err, fleet) {
+				if (err) {
 					return failure(respond(500, "Error retrieving spot fleet data: " + err, false));
-			}
+				}
 
-			if (fleet.SpotFleetRequestConfigs.length < 1) {
-				// TODO: Set the campaign to inactive if this result is reliable enough.
+				if (fleet.SpotFleetRequestConfigs.length < 1) {
+					// TODO: Set the campaign to inactive if this result is reliable enough.
 					return failure(respond(404, "Error retrieving spot fleet data: not found.", false));
-			}
+				}
 
 				success(fleet.SpotFleetRequestConfigs[0])
 			})
 		}).then(request => {
 			if (request.SpotFleetRequestState == "active") {
 				return new Promise((success, failure) => {
-				ec2.cancelSpotFleetRequests({
-					SpotFleetRequestIds: [campaign.spotFleetRequestId],
-					TerminateInstances: true
-				}, function(err, response) {
-					if (err) {
-							return failure(respond(500, "Error cancelling spot fleet: " + err, false));
-					}
+						ec2.cancelSpotFleetRequests({
+							SpotFleetRequestIds: [campaign.spotFleetRequestId],
+							TerminateInstances: true
+						}, function (err, response) {
+							if (err) {
+								return failure(respond(500, "Error cancelling spot fleet: " + err, false));
+							}
 
-					console.log(response);
+							console.log(response);
 
-					if (response.SuccessfulFleetRequests.length < 1) {
-							return failure(respond(500, "Error cancelling spot fleet: " + err, false));
-					}
+							if (response.SuccessfulFleetRequests.length < 1) {
+								return failure(respond(500, "Error cancelling spot fleet: " + err, false));
+							}
 
-					if (response.SuccessfulFleetRequests[0].CurrentSpotFleetRequestState.indexOf('cancelled') < 0) {
-							return failure(respond(400, "Error cancelling spot fleet. Current state: " + response.SuccessfulFleetRequests[0].CurrentSpotFleetRequestState, false));
-					}
+							if (response.SuccessfulFleetRequests[0].CurrentSpotFleetRequestState.indexOf('cancelled') < 0) {
+								return failure(respond(400, "Error cancelling spot fleet. Current state: " + response.SuccessfulFleetRequests[0].CurrentSpotFleetRequestState, false));
+							}
 
-						success(true)
-					});
-				})
-				.then(() => {
-					return editCampaign(entity, campaignId, {
-						active: false
+							success(true)
+						});
 					})
-				})
+					.then(() => {
+						return editCampaign(entity, campaignId, {
+							active: false
+						})
+					})
 			} else {
 				return editCampaign(entity, campaignId, {
 					active: false,
 					status: "CANCELLED"
 				})
 			}
-				}).then(function(data) {
-					return respond(200, "Campaign stoppped.", true);
-				}, function (err) {
-					return respond(500, "Unable to deactivate campaign: " + err, false);
+		}).then(function (data) {
+			return respond(200, "Campaign stoppped.", true);
+		}, function (err) {
+			return respond(500, "Unable to deactivate campaign: " + err, false);
 		})
 	}, function (err) {
 		return respond(500, "Error retrieving campaign: " + err, false);


### PR DESCRIPTION
At least on my NPK instance, the proxy_api_handler lambda function would return a 500 error whenever it would try to stop the campaign. Once I fully promisified the stopCampaign method, it worked without any issues.