### PR TITLE
missing ',' in npk-settings and small fix for deploy-selfhost.sh

### DIFF
--- a/terraform/npk-settings.json.sample
+++ b/terraform/npk-settings.json.sample
@@ -1,5 +1,5 @@
 {
-  "backend_bucket": "terraform-backend-<somerandomcharacters>"
+  "backend_bucket": "terraform-backend-<somerandomcharacters>",
   "campaign_data_ttl": 604800,
   "campaign_max_price": 50,
   "georestrictions": ["US", "CA", "GB", "DE"],
@@ -18,7 +18,7 @@
   "awsProfile": "npk",
   "criticalEventsSMS": "+13035551234",
   "adminEmail": "demo@npkproject.io",
-  "debug_lambda": false
+  "debug_lambda": false,
 
   "useSAML": false,
   "sAMLMetadataDocument": "/home/self/Documents/CorpSAMLMetadata.xml"


### PR DESCRIPTION
When deploy-selfhost.sh is run before deploy.sh the regions.json is missing which is needed by terraform-selfhost.jsonnet.
Copied the creating of regions.json from deploy.sh and adapted the paths to make sure its available.