### PR TITLE
missing ',' in npk-settings, switch to Amazon Linux 2 AMI and small fixes for deploy-selfhost.sh, deploy.sh and userdata.sh

### DIFF
--- a/terraform-selfhost/deploy-selfhost.sh
+++ b/terraform-selfhost/deploy-selfhost.sh
@@ -73,6 +73,11 @@ export AWS_DEFAULT_REGION=us-west-2
 export AWS_DEFAULT_OUTPUT=json
 export AWS_PROFILE=$PROFILE
 
+# Disable Pager for AWS CLI v2
+if [[ $(aws --version | grep "aws-cli/2" | wc -l) -ge 1 ]]; then
+	export AWS_PAGER="";
+fi
+
 BUCKET=$(jq -r '.backend_bucket' ../terraform/npk-settings.json)
 
 if [[ "$BUCKET" == "" ]]; then

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -198,12 +198,12 @@ if [[ ! -d .terraform ]]; then
 	# check if roles already exist
 	SPOTROLE=$(aws iam list-roles | jq '.Roles[] | select(.RoleName == "AWSServiceRoleForEC2Spot") | .RoleName')
 	FLEETROLE=$(aws iam list-roles | jq '.Roles[] | select(.RoleName == "AWSServiceRoleForEC2SpotFleet") | .RoleName')
-	if [ -r $SPOTROLE]; then 
+	if [ -r $SPOTROLE ]; then 
 		aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
 	else
 		echo "[*] AWSServiceRoleForEC2Spot already exists"
 	fi
-	if [ -r $FLEETROLE]; then 
+	if [ -r $FLEETROLE ]; then 
 		aws iam create-service-linked-role --aws-service-name spotfleet.amazonaws.com
 	else 
 		echo "[*] AWSServiceRoleForEC2SpotFleet already exists"

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -194,8 +194,20 @@ fi
 
 if [[ ! -d .terraform ]]; then
 	echo "[+] Creating service-linked roles for EC2 spot fleets"
-	aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
-	aws iam create-service-linked-role --aws-service-name spotfleet.amazonaws.com
+	
+	# check if roles already exist
+	SPOTROLE=$(aws iam list-roles | jq '.Roles[] | select(.RoleName == "AWSServiceRoleForEC2Spot") | .RoleName')
+	FLEETROLE=$(aws iam list-roles | jq '.Roles[] | select(.RoleName == "AWSServiceRoleForEC2SpotFleet") | .RoleName')
+	if [ -r $SPOTROLE]; then 
+		aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
+	else
+		echo "[*] AWSServiceRoleForEC2Spot already exists"
+	fi
+	if [ -r $FLEETROLE]; then 
+		aws iam create-service-linked-role --aws-service-name spotfleet.amazonaws.com
+	else 
+		echo "[*] AWSServiceRoleForEC2SpotFleet already exists"
+	fi
 fi
 
 # remove old configs silently:

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -68,6 +68,11 @@ export AWS_DEFAULT_REGION=us-west-2
 export AWS_DEFAULT_OUTPUT=json
 export AWS_PROFILE=$PROFILE
 
+# Disable Pager for AWS CLI v2
+if [[ $(aws --version | grep "aws-cli/2" | wc -l) -ge 1 ]]; then
+	export AWS_PAGER="";
+fi
+
 BUCKET=$(jq -r '.backend_bucket' npk-settings.json)
 
 if [[ "$BUCKET" == "" ]]; then

--- a/terraform/jsonnet/null_resources.libsonnet
+++ b/terraform/jsonnet/null_resources.libsonnet
@@ -22,7 +22,7 @@
 						}
 					}],
 
-					"depends_on": ["aws_cognito_user_pool.npk", "aws_cognito_identity_pool.main"],
+					"depends_on": ["aws_cognito_user_pool.npk", "aws_cognito_identity_pool.main", "aws_cognito_user_group.npk-admins"],
 					"triggers": {
 						"username": "${random_string.admin_password.keepers.admin_email}"
 					}

--- a/terraform/lambda_functions/proxy_api_handler/main.js
+++ b/terraform/lambda_functions/proxy_api_handler/main.js
@@ -316,7 +316,7 @@ function getNVidiaImage(region) {
                 Values: ["hvm"]
             },{
             	Name: "name",
-            	Values: ["amzn-ami-graphics-hvm-20*"]
+            	Values: ["amzn2-ami-graphics-hvm-2*"]
             },{
             	Name: "root-device-type",
             	Values: ["ebs"]

--- a/terraform/npk-settings.json.sample
+++ b/terraform/npk-settings.json.sample
@@ -1,5 +1,5 @@
 {
-  "backend_bucket": "terraform-backend-<somerandomcharacters>"
+  "backend_bucket": "terraform-backend-<somerandomcharacters>",
   "campaign_data_ttl": 604800,
   "campaign_max_price": 50,
   "georestrictions": ["US", "CA", "GB", "DE"],
@@ -18,7 +18,7 @@
   "awsProfile": "npk",
   "criticalEventsSMS": "+13035551234",
   "adminEmail": "demo@npkproject.io",
-  "debug_lambda": false
+  "debug_lambda": false,
 
   "useSAML": false,
   "sAMLMetadataDocument": "/home/self/Documents/CorpSAMLMetadata.xml"

--- a/terraform/templates/userdata.tpl
+++ b/terraform/templates/userdata.tpl
@@ -86,7 +86,7 @@ mv maskprocessor-*/ maskprocessor
 
 MANUALARGS=""
 if [[ "$(jq '.manualArguments' manifest.json)" != "null" ]]; then
-	MANUALARGS=$(jq -r '.manualArguments |= split(" ") | .manualArguments[]' /root/manifest.json | xargs printf "%q\n")
+	MANUALARGS=$(jq -r '.manualArguments |= split(" ") | .manualArguments[]' /root/manifest.json | xargs -I {} sh -c "printf \"%q\n\" \"{}\"")
 fi
 
 echo "[*] using manual args [ $MANUALARGS ]"

--- a/terraform/templates/userdata.tpl
+++ b/terraform/templates/userdata.tpl
@@ -97,12 +97,33 @@ echo "[*] using manual args [ $MANUALARGS ]"
 # el
 
 if [[ "$(jq -r '.attackType' manifest.json)" == "3" ]]; then
-	if [[ "$(jq '.manualMask' manifest.json)" == "null" ]]; then
-		KEYSPACE=$(/root/hashcat/hashcat.bin --keyspace -a 3 $(jq -r '.mask' /root/manifest.json))
+
+	MASK=$(jq -r '.mask + .manualMask' manifest.json)
+
+	if  [[ $(echo $MANUALARGS | grep 'increment' | wc -l) -lt 1 ]]; then
+		KEYSPACE=$(hashcat --keyspace -a 3 $MANUALARGS $MASK)
 		KEYSPACERC=$?
 	else
-		KEYSPACE=$(/root/hashcat/hashcat.bin --keyspace -a 3 $MANUALARGS $(jq -r '.manualMask' /root/manifest.json))
-		KEYSPACERC=$?
+		# --increment flag was provided
+		KEYSPACE=0
+		# n of "--increment-min n" or 2 if increment-min was not set 
+		ITERMIN=$(echo "$MANUALARGS" | grep -zoP '(?<=\--increment-min\n)\d{1,}(?=\n)' | sed 's/\x0//g') 
+		ITERMIN=$${ITERMIN:-1}
+
+		# n of "--increment-max n" or get it directly from the mask 
+		ITERMAX=$(echo "$MANUALARGS" | grep -zoP '(?<=\--increment-max\n)\d{1,}(?=\n)' | sed 's/\x0//g')
+		ITERMAX=$${ITERMAX:-$(($(echo $MASK | sed 's/\?//g' | wc -c)/2))}
+		
+		# iterate over each increment
+		for ITER in $(seq $ITERMIN $ITERMAX)		
+		do
+			ITEROFFSET=$(($ITER*2))
+			ITERMASK=$(echo $${MASK:0:$ITEROFFSET}) 
+
+			ITERKEYSPACE=$(/root/hashcat/hashcat.bin --keyspace -a 3 $ITERMASK)
+			KEYSPACERC=$?
+			KEYSPACE=$(($KEYSPACE + $ITERKEYSPACE))
+		done
 	fi
 else
 	KEYSPACE=$(/root/hashcat/hashcat.bin --keyspace -a $(jq -r '.attackType' /root/manifest.json) $MANUALARGS npk-wordlist/*)

--- a/terraform/templates/userdata.tpl
+++ b/terraform/templates/userdata.tpl
@@ -86,7 +86,7 @@ mv maskprocessor-*/ maskprocessor
 
 MANUALARGS=""
 if [[ "$(jq '.manualArguments' manifest.json)" != "null" ]]; then
-	MANUALARGS=$(jq -r '.manualArguments |= split(" ") | .test[]' /root/manifest.json | xargs printf "%q\n")
+	MANUALARGS=$(jq -r '.manualArguments |= split(" ") | .manualArguments[]' /root/manifest.json | xargs printf "%q\n")
 fi
 
 echo "[*] using manual args [ $MANUALARGS ]"


### PR DESCRIPTION
- Missing ',' characters in npk-settings.json

- When deploy-selfhost.sh is run before deploy.sh the regions.json is missing which is needed by terraform-selfhost.jsonnet.
Copied the creating of regions.json from deploy.sh and adapted the paths to make sure its available.

- Disable Pager for AWS CLI v2 as else some returns cause the deployment to get "stuck" because the user has to quit less (which seems to be the default) with ':q'

- Check if iam roles already exist (from previous deployments etc.) and only create them if needed since deploy.sh has errors when the roles already exist

- Fix for https://github.com/Coalfire-Research/npk/issues/123

- Switch to new Amazon Linux 2 AMI with NVIDIA TESLA GPU Driver (https://aws.amazon.com/marketplace/pp/Amazon-Web-Services-Amazon-Linux-2-AMI-with-NVIDIA/B07S5G9S1Z) for performance gains.

- Fix ManualArgs in userdata.sh