### PR TITLE
Pin AWSCLI version and update dependency checks

### DIFF
--- a/terraform-selfhost/deploy-selfhost.sh
+++ b/terraform-selfhost/deploy-selfhost.sh
@@ -22,9 +22,9 @@ if [[ ! -f $(which aws) ]]; then
 	echo "Error: Must have AWSCLI installed.";
 fi
 
-if [[ $(aws --version | grep "aws-cli/2" | wc -l) -lt 1 ]]; then
+if [[ $(aws --version | grep -c "aws-cli/2") != 1 ]]; then
 	ERR=1;
-	echo "Error: NPK Selfhost requires AWSCLI version 2.";
+	echo "Error: Wrong version of Terraform is installed. NPK requires AWSCLI version 2.";
 fi
 
 if [[ ! -f $(which npm) ]]; then
@@ -37,7 +37,7 @@ if [[ ! -f $(which terraform) ]]; then
 	echo "Error: Must have Terraform installed.";
 fi
 
-if [[ "$(terraform -v | grep v0.11 | wc -l)" != "1" ]]; then
+if [[ $($TERBIN -v | grep -c "Terraform v0.11") != 1 ]]; then
 	ERR=1;
 	echo "Error: Wrong version of Terraform is installed. NPK requires Terraform v0.11.";
 	echo "-> Note: A non-default binary can be specified as a positional script parameter:"

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -22,6 +22,11 @@ if [[ ! -f $(which aws) ]]; then
 	echo "Error: Must have AWSCLI installed.";
 fi
 
+if [[ $(aws --version | grep -c "aws-cli/2") != 1 ]]; then
+	ERR=1;
+	echo "Error: Wrong version of Terraform is installed. NPK requires AWSCLI version 2.";
+fi
+
 if [[ ! -f $(which npm) ]]; then
 	ERR=1;
 	echo "Error: Must have NPM installed.";
@@ -32,10 +37,10 @@ if [[ ! -f $(which terraform) ]]; then
 	echo "Error: Must have Terraform installed.";
 fi
 
-if [[ "$($TERBIN -v | grep v0.11 | wc -l)" != "1" ]]; then
+if [[ $($TERBIN -v | grep -c "Terraform v0.11") != 1 ]]; then
 	ERR=1;
 	echo "Error: Wrong version of Terraform is installed. NPK requires Terraform v0.11.";
-	echo "-> Note: A non-default binary can be specified as positional script parameter:"
+	echo "-> Note: A non-default binary can be specified as a positional script parameter:"
 	echo "-> e.g: ./deploy-selfhost.sh <terraform-v0.11-path>"
 	echo ""
 fi
@@ -213,7 +218,6 @@ fi
 # remove old configs silently:
 rm -f *.tf.json
 
-
 echo "[*] Generating Terraform configurations"
 jsonnet -m . terraform.jsonnet
 
@@ -236,4 +240,4 @@ if [[ ! -d .terraform || $ISINIT -ne 0 ]]; then
 	fi
 fi
 
-terraform apply -auto-approve
+ $TERBIN apply -auto-approve


### PR DESCRIPTION
📌 Pin AWSCLI to version 2

📌 Use `grep -c` for terraform dependency check
The `-c` flag counts the number of matches. A bit cleaner than `wc -l`